### PR TITLE
global-storage要らなかった

### DIFF
--- a/.github/workflows/test-linux-gcc.yml
+++ b/.github/workflows/test-linux-gcc.yml
@@ -10,7 +10,7 @@ jobs:
   test-linux-gcc:
     strategy:
       matrix:
-        dep: ["apt", "source"]
+        dep: ["source"]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build
-        if [[ ${{matrix.dep}} = apt ]]; then sudo apt-get install -y libdwarf-dev; fi
+      # if [[ ${{matrix.dep}} = apt ]]; then sudo apt-get install -y libdwarf-dev; fi
     - name: Install meson
       run: pip install meson || pip install --break-system-packages meson
     - name: Setup Meson

--- a/examples/ptr-local.cc
+++ b/examples/ptr-local.cc
@@ -5,6 +5,7 @@ int main() {
     y3c::ptr<int> p;
     {
         y3c::wrap<int> a = 42;
+        p = &a;
         std::cout << *p << std::endl;
     }
     std::cout << *p << std::endl;

--- a/include/y3c/array.h
+++ b/include/y3c/array.h
@@ -15,7 +15,7 @@ Y3C_NS_BEGIN
  * std::arrayと違って集成体初期化はできない
  * (できるようにする必要はあるのか?)
  */
-template <class T, std::size_t N>
+template <typename T, std::size_t N>
 class array : wrap<std::array<T, N>> {
   public:
     array() = default;
@@ -49,20 +49,23 @@ class array : wrap<std::array<T, N>> {
     using const_pointer = const_ptr<T>;
     using value_type = T;
 
-    wrap_auto<T> at(size_type n) {
+    wrap_auto<T> at(size_type n, internal::skip_trace_tag = {}) {
         if (n >= N) {
-            throw y3c::out_of_range("y3c::array::at()", N, n);
+            throw y3c::out_of_range("y3c::array::at()", N,
+                                    static_cast<std::ptrdiff_t>(n));
         }
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap()[n],
                             this->alive());
     }
-    wrap_auto<const T> at(size_type n) const {
+    wrap_auto<const T> at(size_type n, internal::skip_trace_tag = {}) const {
         if (n >= N) {
-            throw y3c::out_of_range("y3c::array::at()", N, n);
+            throw y3c::out_of_range("y3c::array::at()", N,
+                                    static_cast<std::ptrdiff_t>(n));
         }
         return wrap_auto<const T>(&this->unwrap().front(), N,
                                   &this->unwrap()[n], this->alive());
     }
+    template <typename = internal::skip_trace_tag>
     wrap_auto<T> operator[](size_type n) {
         if (n >= N) {
             y3c::internal::terminate_ub_out_of_range(
@@ -71,6 +74,7 @@ class array : wrap<std::array<T, N>> {
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap()[n],
                             this->alive());
     }
+    template <typename = internal::skip_trace_tag>
     wrap_auto<const T> operator[](size_type n) const {
         if (n >= N) {
             y3c::internal::terminate_ub_out_of_range(
@@ -80,7 +84,7 @@ class array : wrap<std::array<T, N>> {
                                   &this->unwrap()[n], this->alive());
     }
 
-    wrap_auto<T> front() {
+    wrap_auto<T> front(internal::skip_trace_tag = {}) {
         if (N == 0) {
             y3c::internal::terminate_ub_out_of_range("y3c::array::front()", N,
                                                      0);
@@ -88,7 +92,7 @@ class array : wrap<std::array<T, N>> {
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap().front(),
                             this->alive());
     }
-    wrap_auto<const T> front() const {
+    wrap_auto<const T> front(internal::skip_trace_tag = {}) const {
         if (N == 0) {
             y3c::internal::terminate_ub_out_of_range("y3c::array::front()", N,
                                                      0);
@@ -96,7 +100,7 @@ class array : wrap<std::array<T, N>> {
         return wrap_auto<const T>(&this->unwrap().front(), N,
                                   &this->unwrap().front(), this->alive());
     }
-    wrap_auto<T> back() {
+    wrap_auto<T> back(internal::skip_trace_tag = {}) {
         if (N == 0) {
             y3c::internal::terminate_ub_out_of_range("y3c::array::back()", N,
                                                      0);
@@ -104,7 +108,7 @@ class array : wrap<std::array<T, N>> {
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap().back(),
                             this->alive());
     }
-    wrap_auto<const T> back() const {
+    wrap_auto<const T> back(internal::skip_trace_tag = {}) const {
         if (N == 0) {
             y3c::internal::terminate_ub_out_of_range("y3c::array::back()", N,
                                                      0);

--- a/include/y3c/array.h
+++ b/include/y3c/array.h
@@ -54,63 +54,63 @@ class array : wrap<std::array<T, N>> {
             throw y3c::out_of_range("y3c::array::at()", N, n);
         }
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap()[n],
-                         this->alive());
+                            this->alive());
     }
     wrap_auto<const T> at(size_type n) const {
         if (n >= N) {
             throw y3c::out_of_range("y3c::array::at()", N, n);
         }
-        return wrap_auto<const T>(&this->unwrap().front(), N, &this->unwrap()[n],
-                               this->alive());
+        return wrap_auto<const T>(&this->unwrap().front(), N,
+                                  &this->unwrap()[n], this->alive());
     }
     wrap_auto<T> operator[](size_type n) {
         if (n >= N) {
-            y3c::internal::undefined_behavior("y3c::array::operator[]()",
-                                              y3c::msg::out_of_range(N, n));
+            y3c::internal::terminate_ub_out_of_range(
+                "y3c::array::operator[]()", N, static_cast<std::ptrdiff_t>(n));
         }
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap()[n],
-                         this->alive());
+                            this->alive());
     }
     wrap_auto<const T> operator[](size_type n) const {
         if (n >= N) {
-            y3c::internal::undefined_behavior("y3c::array::operator[]()",
-                                              y3c::msg::out_of_range(N, n));
+            y3c::internal::terminate_ub_out_of_range(
+                "y3c::array::operator[]()", N, static_cast<std::ptrdiff_t>(n));
         }
-        return wrap_auto<const T>(&this->unwrap().front(), N, &this->unwrap()[n],
-                               this->alive());
+        return wrap_auto<const T>(&this->unwrap().front(), N,
+                                  &this->unwrap()[n], this->alive());
     }
 
     wrap_auto<T> front() {
         if (N == 0) {
-            y3c::internal::undefined_behavior("y3c::array::front()",
-                                              y3c::msg::out_of_range(N, 0LL));
+            y3c::internal::terminate_ub_out_of_range("y3c::array::front()", N,
+                                                     0);
         }
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap().front(),
-                         this->alive());
+                            this->alive());
     }
     wrap_auto<const T> front() const {
         if (N == 0) {
-            y3c::internal::undefined_behavior("y3c::array::front()",
-                                              y3c::msg::out_of_range(N, 0LL));
+            y3c::internal::terminate_ub_out_of_range("y3c::array::front()", N,
+                                                     0);
         }
         return wrap_auto<const T>(&this->unwrap().front(), N,
-                               &this->unwrap().front(), this->alive());
+                                  &this->unwrap().front(), this->alive());
     }
     wrap_auto<T> back() {
         if (N == 0) {
-            y3c::internal::undefined_behavior("y3c::array::back()",
-                                              y3c::msg::out_of_range(N, 0LL));
+            y3c::internal::terminate_ub_out_of_range("y3c::array::back()", N,
+                                                     0);
         }
         return wrap_auto<T>(&this->unwrap().front(), N, &this->unwrap().back(),
-                         this->alive());
+                            this->alive());
     }
     wrap_auto<const T> back() const {
         if (N == 0) {
-            y3c::internal::undefined_behavior("y3c::array::back()",
-                                              y3c::msg::out_of_range(N, 0LL));
+            y3c::internal::terminate_ub_out_of_range("y3c::array::back()", N,
+                                                     0);
         }
         return wrap_auto<const T>(&this->unwrap().front(), N,
-                               &this->unwrap().back(), this->alive());
+                                  &this->unwrap().back(), this->alive());
     }
 
     pointer data() {

--- a/include/y3c/shared_ptr.h
+++ b/include/y3c/shared_ptr.h
@@ -130,7 +130,7 @@ class shared_ptr : public wrap<std::shared_ptr<T>> {
     ptr<element_type> get() const noexcept {
         return ptr<element_type>(this->unwrap().get(), ptr_alive_);
     }
-    template <typename U = T>
+    template <typename U = T, typename = internal::skip_trace_tag>
     y3c::wrap_auto<U> operator*() const {
         if (!this->unwrap()) {
             y3c::internal::terminate_ub_access_nullptr(
@@ -139,6 +139,7 @@ class shared_ptr : public wrap<std::shared_ptr<T>> {
         assert(ptr_alive_);
         return y3c::wrap_auto<T>(this->unwrap().get(), ptr_alive_);
     }
+    template <typename = internal::skip_trace_tag>
     element_type *operator->() const {
         if (!this->unwrap()) {
             y3c::internal::terminate_ub_access_nullptr(

--- a/include/y3c/shared_ptr.h
+++ b/include/y3c/shared_ptr.h
@@ -133,16 +133,16 @@ class shared_ptr : public wrap<std::shared_ptr<T>> {
     template <typename U = T>
     y3c::wrap_auto<U> operator*() const {
         if (!this->unwrap()) {
-            y3c::internal::undefined_behavior("y3c::shared_ptr::operator*()",
-                                              y3c::msg::access_nullptr());
+            y3c::internal::terminate_ub_access_nullptr(
+                "y3c::shared_ptr::operator*()");
         }
         assert(ptr_alive_);
         return y3c::wrap_auto<T>(this->unwrap().get(), ptr_alive_);
     }
     element_type *operator->() const {
         if (!this->unwrap()) {
-            y3c::internal::undefined_behavior("y3c::shared_ptr::operator->()",
-                                              y3c::msg::access_nullptr());
+            y3c::internal::terminate_ub_access_nullptr(
+                "y3c::shared_ptr::operator->()");
         }
         assert(ptr_alive_);
         return this->unwrap().get();

--- a/include/y3c/wrap.h
+++ b/include/y3c/wrap.h
@@ -149,16 +149,16 @@ class wrap_ref {
   protected:
     element_type *ptr_unwrap(const char *func) const {
         if (!ptr_) {
-            y3c::internal::undefined_behavior(func, y3c::msg::access_nullptr());
+            y3c::internal::terminate_ub_access_nullptr(func);
         }
         assert(range_alive_);
         if (!*range_alive_) {
-            y3c::internal::undefined_behavior(func, y3c::msg::access_deleted());
+            y3c::internal::terminate_ub_access_deleted(func);
         }
-        if (ptr_ - begin_ < 0 || ptr_ - begin_ >= size_) {
-            y3c::internal::undefined_behavior(
-                func, y3c::msg::out_of_range(
-                          size_, static_cast<long long>(ptr_ - begin_)));
+        if (ptr_ - begin_ < 0 ||
+            ptr_ - begin_ >= static_cast<std::ptrdiff_t>(size_)) {
+            y3c::internal::terminate_ub_out_of_range(func, size_,
+                                                     ptr_ - begin_);
         }
         return ptr_;
     }
@@ -363,17 +363,16 @@ class ptr : public wrap<T *> {
 
     element_type *ptr_unwrap(const char *func) const {
         if (!this->unwrap()) {
-            y3c::internal::undefined_behavior(func, y3c::msg::access_nullptr());
+            y3c::internal::terminate_ub_access_nullptr(func);
         }
         assert(range_alive_);
         if (!*range_alive_) {
-            y3c::internal::undefined_behavior(func, y3c::msg::access_deleted());
+            y3c::internal::terminate_ub_access_deleted(func);
         }
-        if (this->unwrap() - begin_ < 0 || this->unwrap() - begin_ >= size_) {
-            y3c::internal::undefined_behavior(
-                func,
-                y3c::msg::out_of_range(
-                    size_, static_cast<long long>(this->unwrap() - begin_)));
+        if (this->unwrap() - begin_ < 0 ||
+            this->unwrap() - begin_ >= static_cast<std::ptrdiff_t>(size_)) {
+            y3c::internal::terminate_ub_out_of_range(func, size_,
+                                                     this->unwrap() - begin_);
         }
         return this->unwrap();
     }

--- a/src/detail.cc
+++ b/src/detail.cc
@@ -8,7 +8,7 @@ void link() noexcept {}
 namespace internal {
 
 exception_base::exception_base(const char *e_class, std::string &&func,
-                               std::string &&what)
+                               std::string &&what, skip_trace_tag)
     : detail(std::make_shared<exception_detail>(
           terminate_type::exception, e_class, std::move(func), std::move(what),
           cpptrace::generate_raw_trace())) {}

--- a/src/detail.cc
+++ b/src/detail.cc
@@ -10,8 +10,8 @@ namespace internal {
 exception_base::exception_base(const char *e_class, std::string &&func,
                                std::string &&what)
     : detail(std::make_shared<exception_detail>(
-          exception_type_enum::exception, e_class, std::move(func),
-          std::move(what), cpptrace::generate_raw_trace())) {}
+          terminate_type::exception, e_class, std::move(func), std::move(what),
+          cpptrace::generate_raw_trace())) {}
 
 const char *exception_base::what() const noexcept {
     return std::static_pointer_cast<exception_detail>(this->detail)
@@ -22,9 +22,8 @@ const char *exception_base::what() const noexcept {
 bool throw_on_terminate =
     (std::set_terminate(handle_final_terminate_message), false);
 
-exception_detail::exception_detail(exception_type_enum type,
-                                   const char *e_class, std::string &&func,
-                                   std::string &&what,
+exception_detail::exception_detail(terminate_type type, const char *e_class,
+                                   std::string &&func, std::string &&what,
                                    cpptrace::raw_trace &&raw_trace)
     : type(type), e_class(e_class), func(std::move(func)),
       what(std::move(what)), raw_trace(std::move(raw_trace)) {}

--- a/src/detail.cc
+++ b/src/detail.cc
@@ -7,34 +7,20 @@ void link() noexcept {}
 
 namespace internal {
 
-[[noreturn]] void do_terminate_with(exception_type_enum type,
-                                    const char *e_class, std::string &&func,
-                                    std::string &&what) {
-    get_global_storage().add_exception(type, e_class, std::move(func),
-                                       std::move(what),
-                                       cpptrace::generate_raw_trace());
-    std::terminate();
-}
-
 exception_base::exception_base(const char *e_class, std::string &&func,
                                std::string &&what)
-    : detail_id_(get_global_storage().add_exception(
+    : detail(std::make_shared<exception_detail>(
           exception_type_enum::exception, e_class, std::move(func),
           std::move(what), cpptrace::generate_raw_trace())) {}
-exception_base::exception_base(const exception_base &other)
-    : detail_id_(get_global_storage().copy_exception(other.detail_id_)) {}
-exception_base &exception_base::operator=(const exception_base &other) {
-    if (this != &other) {
-        detail_id_ = get_global_storage().copy_exception(other.detail_id_);
-    }
-    return *this;
+
+const char *exception_base::what() const noexcept {
+    return std::static_pointer_cast<exception_detail>(this->detail)
+        ->what.c_str();
 }
 
-exception_base::~exception_base() noexcept {
-    get_global_storage().remove_exception(detail_id_);
-}
-
-bool throw_on_terminate = false;
+// グローバル変数初期化のタイミングでset_terminateを呼び、そのついでにfalseで初期化
+bool throw_on_terminate =
+    (std::set_terminate(handle_final_terminate_message), false);
 
 exception_detail::exception_detail(exception_type_enum type,
                                    const char *e_class, std::string &&func,
@@ -42,64 +28,6 @@ exception_detail::exception_detail(exception_type_enum type,
                                    cpptrace::raw_trace &&raw_trace)
     : type(type), e_class(e_class), func(std::move(func)),
       what(std::move(what)), raw_trace(std::move(raw_trace)) {}
-
-global_storage::global_storage() {
-    std::set_terminate(handle_final_terminate_message);
-}
-
-global_storage::~global_storage() {
-    std::lock_guard<std::mutex> lock(m);
-    initialized = false;
-    exceptions.clear();
-}
-
-int global_storage::add_exception(exception_type_enum type, const char *e_class,
-                                  std::string &&func, std::string &&what,
-                                  cpptrace::raw_trace &&raw_trace) {
-    if (!alive()) {
-        return 0;
-    }
-    std::lock_guard<std::mutex> lock(m);
-    if (!alive()) {
-        return 0;
-    }
-    int detail_id = ++last_detail_id;
-    exceptions.emplace(detail_id, std::make_shared<exception_detail>(
-                                      type, e_class, std::move(func),
-                                      std::move(what), std::move(raw_trace)));
-    return detail_id;
-}
-int global_storage::copy_exception(int old_detail_id) {
-    if (!alive()) {
-        return 0;
-    }
-    std::lock_guard<std::mutex> lock(m);
-    if (!alive()) {
-        return 0;
-    }
-    int detail_id = ++last_detail_id;
-    if (exceptions.count(old_detail_id)) {
-        exceptions.emplace(detail_id, exceptions.at(old_detail_id));
-    }
-    return detail_id;
-}
-void global_storage::remove_exception(int detail_id) {
-    if (!alive()) {
-        return;
-    }
-    std::lock_guard<std::mutex> lock(m);
-    if (!alive()) {
-        return;
-    }
-    exceptions.erase(detail_id);
-}
-
-global_storage &get_global_storage() {
-    static global_storage storage;
-    return storage;
-}
-
-global_storage *storage_early_init = &get_global_storage();
 
 } // namespace internal
 

--- a/src/detail.h
+++ b/src/detail.h
@@ -2,9 +2,6 @@
 #include "y3c/internal.h"
 #include <cpptrace/basic.hpp>
 #include <string>
-#include <unordered_map>
-#include <mutex>
-#include <memory>
 
 Y3C_NS_BEGIN
 namespace internal {
@@ -20,66 +17,6 @@ struct exception_detail {
                      std::string &&func, std::string &&what,
                      cpptrace::raw_trace &&raw_trace);
 };
-
-/*!
- * exceptionの情報などを保存するクラス。
- * static変数のシングルトン。
- *
- * これが破棄される時、ただのbool変数であるinitializedがfalseになり、判別できるようにする。
- * その場合exception情報のアクセスは諦める
- *
- */
-class global_storage {
-    std::unordered_map<int, std::shared_ptr<exception_detail>> exceptions;
-    int last_detail_id = 0;
-    std::mutex m;
-    bool initialized = true;
-
-  public:
-    global_storage();
-    global_storage(const global_storage &) = delete;
-    global_storage &operator=(const global_storage &) = delete;
-    global_storage(global_storage &&) = delete;
-    global_storage &operator=(global_storage &&) = delete;
-    ~global_storage();
-
-    bool alive() const noexcept { return initialized; }
-    int add_exception(exception_type_enum type, const char *e_class,
-                      std::string &&func, std::string &&what,
-                      cpptrace::raw_trace &&raw_trace);
-    void remove_exception(int detail_id);
-    int copy_exception(int old_detail_id);
-
-    template <typename T1, typename T2, typename T3>
-    void foreach_exception(T1 &&foreach_f, T2 &&on_empty_f, T3 &&on_dead_f) {
-        if (!alive()) {
-            on_dead_f();
-            return;
-        }
-        std::lock_guard<std::mutex> lock(m);
-        if (!alive()) {
-            on_dead_f();
-            return;
-        }
-        if (exceptions.empty()) {
-            on_empty_f();
-            return;
-        }
-        for (const auto &e : exceptions) {
-            foreach_f(e.second);
-        }
-    }
-};
-
-global_storage &get_global_storage();
-
-/*!
- * できるだけ早いタイミングで初期化するために、グローバル変数初期化としてget_global_storage()を呼び出す。
- *
- * これ自体は使わない
- *
- */
-extern global_storage *storage_early_init;
 
 } // namespace internal
 

--- a/src/detail.h
+++ b/src/detail.h
@@ -7,13 +7,13 @@ Y3C_NS_BEGIN
 namespace internal {
 
 struct exception_detail {
-    exception_type_enum type;
+    terminate_type type;
     const char *e_class;
     std::string func;
     std::string what;
     cpptrace::raw_trace raw_trace;
 
-    exception_detail(exception_type_enum type, const char *e_class,
+    exception_detail(terminate_type type, const char *e_class,
                      std::string &&func, std::string &&what,
                      cpptrace::raw_trace &&raw_trace);
 };

--- a/src/final_message.cc
+++ b/src/final_message.cc
@@ -90,68 +90,59 @@ void print_y3c_exception(std::ostream &stream, exception_detail &e) {
 }
 
 void print_current_exception(std::ostream &stream, std::exception_ptr current) {
-    stream << "exception thrown, but that's not from y3c-stl." << std::endl;
     try {
         std::rethrow_exception(current);
+    }catch (const y3c::internal::exception_base &e){
+        auto detail = std::static_pointer_cast<exception_detail>(e.detail);
+        print_y3c_exception(stream, *detail);
+        auto trace = detail->raw_trace.resolve();
+        strip_and_print_trace(stream, trace);
+        return;
     } catch (const std::exception &e) {
+        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
         print_what(stream, "std::exception", nullptr, e.what(), true);
     } catch (const std::string &e) {
+        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
         print_what(stream, "std::string", nullptr, e.c_str(), true);
     } catch (const char *e) {
+        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
         print_what(stream, nullptr, nullptr, e, true);
     } catch (...) {
+        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
         print_what(stream, nullptr, nullptr, nullptr, false);
     }
+    auto trace = cpptrace::generate_trace();
+    strip_and_print_trace(stream, trace);
 }
 [[noreturn]] void handle_final_terminate_message() noexcept {
     auto &stream = std::cerr;
     rang::setControlMode(rang::control::Force);
-    get_global_storage().foreach_exception(
-        [&](const std::shared_ptr<exception_detail> &e) { // foreach
-            // foreachにしているが、ふつうは多くても1つである
-            print_header(stream);
-            assert(e);
-            print_y3c_exception(stream, *e);
-            auto trace = e->raw_trace.resolve();
-            strip_and_print_trace(stream, trace);
-        },
-        [&]() { // empty
-            print_header(stream);
-            auto current = std::current_exception();
-            if (current) {
-                print_current_exception(stream, current);
-            } else {
-                stream << "terminate() called, but that's not from y3c-stl and "
-                          "current_exception information is empty."
-                       << std::endl;
-            }
-            stream << rang::style::italic << rang::style::dim
-                   << "The following stack trace may be inaccurate.";
-            stream << rang::style::reset << std::endl;
-            auto trace = cpptrace::generate_trace();
-            strip_and_print_trace(stream, trace);
-        },
-        [&]() { // dead
-            print_header(stream);
-            stream << rang::style::italic << rang::style::dim
-                   << "cannot provide detailed information "
-                      "because y3c::internal::global_storage no longer exists.";
-            stream << rang::style::reset << std::endl;
-            auto current = std::current_exception();
-            if (current) {
-                print_current_exception(stream, current);
-            } else {
-                stream << "terminate() called, but that's not from y3c-stl and "
-                          "current_exception information is empty."
-                       << std::endl;
-            }
-            stream << rang::style::italic << rang::style::dim
-                   << "The following stack trace may be inaccurate.";
-            stream << rang::style::reset << std::endl;
-            auto trace = cpptrace::generate_trace();
-            strip_and_print_trace(stream, trace);
-        });
+    print_header(stream);
+    auto current = std::current_exception();
+    if (current) {
+        print_current_exception(stream, current);
+    } else {
+        stream << "terminate() called, but that's not from y3c-stl and "
+                  "current_exception information is empty."
+               << std::endl;
+        auto trace = cpptrace::generate_trace();
+        strip_and_print_trace(stream, trace);
+    }
+    std::abort();
+}
 
+[[noreturn]] void do_terminate_with(exception_type_enum type,
+                                    const char *e_class, std::string &&func,
+                                    std::string &&what) {
+    exception_detail detail(type, e_class, std::move(func),
+                                       std::move(what),
+                                       cpptrace::generate_raw_trace());
+    auto &stream = std::cerr;
+    rang::setControlMode(rang::control::Force);
+    print_header(stream);
+    print_y3c_exception(stream, detail);
+    auto trace = cpptrace::generate_trace();
+    strip_and_print_trace(stream, trace);
     std::abort();
 }
 

--- a/src/final_message.cc
+++ b/src/final_message.cc
@@ -36,44 +36,40 @@ void print_header(std::ostream &stream) {
     stream << rang::style::bold << rang::fg::red << "y3c-stl terminated";
     stream << rang::style::reset << ": ";
 }
-void print_what(std::ostream &stream, const char *e_class, const char *func,
-                const char *what, bool quote = false) {
-    stream << "  ";
-    if (e_class) {
-        stream << rang::style::italic << rang::fg::cyan << e_class;
-    }
-    if (e_class && func) {
-        stream << " ";
-    }
-    if (func) {
-        stream << rang::fg::reset << rang::style::italic << rang::style::dim
-               << "at ";
-        stream << rang::style::reset << rang::style::italic << rang::fg::yellow
-               << func;
-    }
-    if (e_class || func) {
-        stream << rang::fg::reset << rang::style::italic << rang::style::dim
-               << ": ";
-    }
-    if (what) {
-        if (quote) {
+void print_what(std::ostream &stream, const char *func, const char *what,
+                bool quote = false) {
+    if (func || what) {
+        stream << "  ";
+        if (func) {
+            stream << rang::style::italic << rang::style::dim << "at ";
+            stream << rang::style::reset << rang::style::italic
+                   << rang::fg::yellow << func;
+            stream << rang::fg::reset << rang::style::italic << rang::style::dim
+                   << ": ";
             stream << rang::style::reset;
-            stream << rang::style::dim << '"';
         }
-        stream << rang::style::reset << what;
-        if (quote) {
-            stream << rang::style::dim << '"';
+        if (what) {
+            if (quote) {
+                stream << rang::style::dim << '"';
+            }
+            stream << rang::style::reset << what;
+            if (quote) {
+                stream << rang::style::dim << '"';
+            }
         }
-    } else {
-        stream << rang::fg::reset << rang::style::italic << rang::style::dim
-               << "unknown exception type.";
+        stream << rang::style::reset << std::endl;
     }
-    stream << rang::style::reset << std::endl;
 }
 void print_y3c_exception(std::ostream &stream, exception_detail &e) {
     switch (e.type) {
     case terminate_type::exception:
-        stream << rang::style::bold << "exception thrown";
+        if (e.e_class) {
+            stream << rang::style::bold << "exception of type ";
+            stream << rang::fg::cyan << e.e_class;
+            stream << rang::fg::reset << " thrown";
+        } else {
+            stream << rang::style::bold << "unsupported type exception thrown";
+        }
         break;
     // case terminate_type::terminate:
     //     stream << rang::style::bold << "terminate() called";
@@ -90,9 +86,7 @@ void print_y3c_exception(std::ostream &stream, exception_detail &e) {
     }
     stream << rang::style::reset << std::endl;
 
-    print_what(stream,
-               e.type == terminate_type::exception ? e.e_class : nullptr,
-               e.func.c_str(), e.what.c_str());
+    print_what(stream, e.func.c_str(), e.what.c_str());
 }
 
 void print_current_exception(std::ostream &stream, std::exception_ptr current,
@@ -106,17 +100,26 @@ void print_current_exception(std::ostream &stream, std::exception_ptr current,
         strip_and_print_trace(stream, trace);
         return;
     } catch (const std::exception &e) {
-        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
-        print_what(stream, "std::exception", nullptr, e.what(), true);
+        stream << "exception of type ";
+        stream << rang::fg::cyan << "std::exception";
+        stream << rang::fg::reset << " thrown, but that's not from y3c-stl."
+               << std::endl;
+        print_what(stream, nullptr, e.what(), true);
     } catch (const std::string &e) {
-        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
-        print_what(stream, "std::string", nullptr, e.c_str(), true);
+        stream << "exception of type ";
+        stream << rang::fg::cyan << "std::string";
+        stream << rang::fg::reset << " thrown, but that's not from y3c-stl."
+               << std::endl;
+        print_what(stream, nullptr, e.c_str(), true);
     } catch (const char *e) {
-        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
-        print_what(stream, nullptr, nullptr, e, true);
+        stream << "exception of type ";
+        stream << rang::fg::cyan << "const char *";
+        stream << rang::fg::reset << " thrown, but that's not from y3c-stl."
+               << std::endl;
+        print_what(stream, nullptr, e, true);
     } catch (...) {
-        stream << "exception thrown, but that's not from y3c-stl." << std::endl;
-        print_what(stream, nullptr, nullptr, nullptr, false);
+        stream << "unsupported type exception thrown, but that's not from y3c-stl." << std::endl;
+        print_what(stream, nullptr, nullptr, false);
     }
     auto trace = cpptrace::generate_trace();
     strip_and_print_trace(stream, trace);

--- a/src/final_message.cc
+++ b/src/final_message.cc
@@ -60,6 +60,11 @@ void print_what(std::ostream &stream, const char *func, const char *what,
         stream << rang::style::reset << std::endl;
     }
 }
+void print_maybe_inaccurate(std::ostream &stream) {
+    stream << rang::style::italic << rang::style::dim
+           << "The following stack trace may be inaccurate.";
+    stream << rang::style::reset << std::endl;
+}
 void print_y3c_exception(std::ostream &stream, exception_detail &e) {
     switch (e.type) {
     case terminate_type::exception:
@@ -118,9 +123,12 @@ void print_current_exception(std::ostream &stream, std::exception_ptr current,
                << std::endl;
         print_what(stream, nullptr, e, true);
     } catch (...) {
-        stream << "unsupported type exception thrown, but that's not from y3c-stl." << std::endl;
+        stream
+            << "unsupported type exception thrown, but that's not from y3c-stl."
+            << std::endl;
         print_what(stream, nullptr, nullptr, false);
     }
+    print_maybe_inaccurate(stream);
     auto trace = cpptrace::generate_trace();
     strip_and_print_trace(stream, trace);
 }
@@ -135,6 +143,7 @@ void print_current_exception(std::ostream &stream, std::exception_ptr current,
         stream << "terminate() called, but that's not from y3c-stl and "
                   "current_exception information is empty."
                << std::endl;
+        print_maybe_inaccurate(stream);
         auto trace = cpptrace::generate_trace();
         strip_and_print_trace(stream, trace);
     }

--- a/src/what.cc
+++ b/src/what.cc
@@ -3,7 +3,7 @@
 
 Y3C_NS_BEGIN
 namespace msg {
-std::string out_of_range(std::size_t size, long long index) {
+std::string out_of_range(std::size_t size, std::ptrdiff_t index) {
     std::ostringstream ss;
     ss << "attempted to access index " << index
        << ", that is outside the bounds of size " << size << ".";

--- a/tests/shared_ptr.cc
+++ b/tests/shared_ptr.cc
@@ -34,31 +34,30 @@ TEST_CASE("shared_ptr") {
         CHECK_EQ(unwrap(r).val, 42);
 
         a.reset();
-        CHECK_THROWS_AS(unwrap(*a).val,
-                        y3c::internal::exception_undefined_behavior);
-        CHECK_THROWS_AS(a->val, y3c::internal::exception_undefined_behavior);
+        CHECK_THROWS_AS(unwrap(*a).val, y3c::internal::ub_access_nullptr);
+        CHECK_THROWS_AS(a->val, y3c::internal::ub_access_nullptr);
         CHECK_EQ(a.get(), nullptr);
         CHECK_EQ(a.use_count(), 0L);
         CHECK_FALSE(static_cast<bool>(a));
         CHECK_FALSE(static_cast<bool>(y3c::unwrap(a)));
 
-        CHECK_THROWS_AS(p->val, y3c::internal::exception_undefined_behavior);
-        CHECK_THROWS_AS(unwrap(r).val, y3c::internal::exception_undefined_behavior);
+        CHECK_THROWS_AS(p->val, y3c::internal::ub_access_deleted);
+        CHECK_THROWS_AS(unwrap(r).val, y3c::internal::ub_access_deleted);
 
         p = a.get();
-        CHECK_THROWS_AS(p->val, y3c::internal::exception_undefined_behavior);
+        CHECK_THROWS_AS(p->val, y3c::internal::ub_access_nullptr);
     }
 
     y3c::shared_ptr<A> a1 = new A(42);
     y3c::ptr<A> p1 = a1.get();
     a1 = new A(42);
-    CHECK_THROWS_AS(p1->val, y3c::internal::exception_undefined_behavior);
+    CHECK_THROWS_AS(p1->val, y3c::internal::ub_access_deleted);
     p1 = a1.get();
 
     y3c::shared_ptr<A> a2 = new B(42);
     y3c::ptr<A> p2 = a2.get();
     a2 = new B(42);
-    CHECK_THROWS_AS(p2->val, y3c::internal::exception_undefined_behavior);
+    CHECK_THROWS_AS(p2->val, y3c::internal::ub_access_deleted);
     p2 = a2.get();
 
     y3c::shared_ptr<A> a3 = a2;
@@ -67,15 +66,15 @@ TEST_CASE("shared_ptr") {
     a2.reset();
     CHECK_EQ(p3->val, 42);
     a3 = a1;
-    CHECK_THROWS_AS(p3->val, y3c::internal::exception_undefined_behavior);
+    CHECK_THROWS_AS(p3->val, y3c::internal::ub_access_deleted);
     p3 = a3.get();
 
     a1.reset();
     CHECK_EQ(p1->val, 42);
     CHECK_EQ(p3->val, 42);
     a3.reset();
-    CHECK_THROWS_AS(p1->val, y3c::internal::exception_undefined_behavior);
-    CHECK_THROWS_AS(p3->val, y3c::internal::exception_undefined_behavior);
+    CHECK_THROWS_AS(p1->val, y3c::internal::ub_access_deleted);
+    CHECK_THROWS_AS(p3->val, y3c::internal::ub_access_deleted);
 
     y3c::shared_ptr<B> b1 = new B(42);
     y3c::shared_ptr<A> a4 = b1;
@@ -92,6 +91,4 @@ TEST_CASE("shared_ptr") {
     ca5 = std::make_shared<B>(42);
     y3c::shared_ptr<const A> ca6 = b1;
     ca6 = b1;
-
-
 }

--- a/tests/wrap.cc
+++ b/tests/wrap.cc
@@ -40,7 +40,7 @@ TEST_CASE("wrap") {
         CHECK_EQ(unwrap(r).val, 200);
     }
 
-    CHECK_THROWS_AS(p->val, y3c::internal::exception_undefined_behavior);
+    CHECK_THROWS_AS(p->val, y3c::internal::ub_access_deleted);
 
     {
         y3c::wrap<int> i = 1;
@@ -57,7 +57,7 @@ TEST_CASE("wrap") {
         CHECK_LT(p2, p3);
         p2++;
         CHECK_EQ(p2, p3);
-        CHECK_THROWS_AS(*p2, y3c::internal::exception_undefined_behavior);
+        CHECK_THROWS_AS(*p2, y3c::internal::ub_out_of_range);
     }
     {
         y3c::wrap<int> a = 1;


### PR DESCRIPTION
* global-storage削除
  * 常にcurrent_exceptionから情報を取得するようにする
* throw_on_terminate で投げる例外の型を細分化 & terminate() の仕様変更
* skip_trace_tag 追加
